### PR TITLE
Use prebuilt protoc for cold builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,9 @@
 common --tool_java_language_version=25
 common --tool_java_runtime_version=remotejdk_25
 
+# Avoid compiling protoc from source during cold builds.
+common --@protobuf//bazel/toolchains:prefer_prebuilt_protoc=true
+
 build --nojava_header_compilation
 build --experimental_strict_java_deps=error
 test --explicit_java_test_deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove the legacy Buildr, Ruby, Rake, Travis, API-diff, and site-publishing infrastructure.
 * Add a GitHub Actions CI gate for the Bazel build.
+* Use Protobuf's prebuilt `protoc` toolchain to speed up cold Bazel builds.
 * Validate core and example modules with the GWT 2.13.1 compiler.
 * Validate Zemeckis with the latest J2CL compiler and linker.
 * Add Bazel-based Maven Central release packaging and lifecycle tooling.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True
 
 bazel_dep(name = "j2cl", version = "20260720")
 bazel_dep(name = "jsinterop_base", version = "20260720")
+bazel_dep(name = "protobuf", version = "33.4")
 bazel_dep(name = "rules_closure", version = "0.16.0")
 bazel_dep(name = "rules_java", version = "9.7.0")
 bazel_dep(name = "rules_jvm_external", version = "6.7")


### PR DESCRIPTION
## Summary

- make Protobuf 33.4 directly visible to the root module
- configure Bazel to use Protobuf's prebuilt `protoc` toolchain
- document the cold-build improvement in the changelog

## Why

Cold builds currently compile and link the full Protobuf compiler from C++ source. In clean-output local builds with the same fetched repositories, the prebuilt toolchain reduced the build from 105.1 seconds and 1,585 actions to 51.3 seconds and 510 actions. Protobuf C/C++ compile actions fell from 210 to zero.

## Validation

- `tools/check.sh`
- all 148 build targets succeeded
- all 7 tests passed
- verified the selected macOS ARM64 binary reports `libprotoc 33.4`
